### PR TITLE
Allow getting a Version with a file hash

### DIFF
--- a/src/api_calls/mod.rs
+++ b/src/api_calls/mod.rs
@@ -15,3 +15,14 @@ pub(crate) fn check_id_slug(input: &str) -> Result<()> {
         false => Ok(()),
     }
 }
+
+/// Verify that a given string `input` is a SHA1 hash
+pub(crate) fn check_sha1_hash(input: &str) -> Result<()> {
+    match regex::Regex::new("^[a-f0-9]{40}$")
+        .unwrap()
+        .is_match(input)
+    {
+        true => Ok(()),
+        false => Err(Error::NotValidHash),
+    }
+}

--- a/src/api_calls/version_calls.rs
+++ b/src/api_calls/version_calls.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api_calls::check_id_slug,
+    api_calls::{check_id_slug, check_sha1_hash},
     request::{request, request_rel},
     structures::version_structs::*,
     Ferinth, Result,
@@ -46,6 +46,28 @@ impl Ferinth {
     pub async fn get_version(&self, version_id: &str) -> Result<Version> {
         check_id_slug(version_id)?;
         Ok(request_rel(self, format!("/version/{}", version_id))
+            .await?
+            .json()
+            .await?)
+    }
+
+    /// Get version with hash `sha1`
+    ///
+    /// Example:
+    /// ```rust
+    /// # let modrinth = ferinth::Ferinth::new("ferinth-example");
+    /// # tokio_test::block_on( async {
+    /// let sodium_version = modrinth .get_version_by_hash("795d4c12bffdb1b21eed5ff87c07ce5ca3c0dcbf") .await?;
+    /// assert_eq!(
+    ///     sodium_version.mod_id,
+    ///     "AANobbMI",
+    /// );
+    /// # Ok::<(), ferinth::Error>(())
+    /// # } );
+    /// ```
+    pub async fn get_version_by_hash(&self, hash: &str) -> Result<Version> {
+        check_sha1_hash(hash)?;
+        Ok(request_rel(self, format!("/version_file/{}", hash))
             .await?
             .json()
             .await?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ pub mod structures;
 pub enum Error {
     #[error("A given string was not base62")]
     NotBase62,
+    #[error("A given string was not a hash")]
+    NotValidHash,
     #[error("{}", .0)]
     ReqwestError(#[from] reqwest::Error),
 }


### PR DESCRIPTION
Small addition of an undocumented API, makes trying to get the corresponding Modrinth mod a whole lot easier.

- [Relevant code](https://github.com/modrinth/labrinth/blob/73a8c302e9c48b173f9c12983b64abf7ac9925b9/src/routes/v1/versions.rs#L186)
- [Example response for the `sodium` mod](https://api.modrinth.com/api/v1/version_file/795d4c12bffdb1b21eed5ff87c07ce5ca3c0dcbf)

Could also consider adding the [`/download`](https://github.com/modrinth/labrinth/blob/73a8c302e9c48b173f9c12983b64abf7ac9925b9/src/routes/v1/versions.rs#L229) part of it