### PR TITLE
V2 bringup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 Sodium.jar
+.history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferinth"
 # The major version specifies which version of the Modrinth API this supports
-version = "1.4.1"
+version = "2.0.0"
 edition = "2021"
 authors = ["theRookieCoder <ileshkt@gmail.com>", "4JX"]
 description = "A simple library to use the Modrinth API in Rust projects"
@@ -13,7 +13,10 @@ categories = ["api-bindings", "asynchronous"]
 exclude = ["example/*"]
 
 [dependencies]
-reqwest = { version = "0", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0", default-features = false, features = [
+    "json",
+    "rustls-tls",
+] }
 chrono = { version = "0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 lazy-regex = "2"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -20,9 +20,9 @@ async fn main() -> Result<(), Error> {
     // You can use the mod ID, or the mod slug
     // The mod ID will never change but the mod slug can change at anytime
     // Using the mod slug
-    let sodium = api.get_mod("sodium").await?;
+    let sodium = api.get_project("sodium").await?;
     // Using the mod ID
-    let sodium = api.get_mod("AANobbMI").await?;
+    let sodium = api.get_project("AANobbMI").await?;
 
     // Now lets get the versions that the Sodium mod has
     let sodium_versions = api.list_versions("AANobbMI").await?;

--- a/src/api_calls/mod.rs
+++ b/src/api_calls/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result};
 
-pub mod mod_calls;
+pub mod project_calls;
 pub mod tag_calls;
 pub mod user_calls;
 pub mod version_calls;

--- a/src/api_calls/mod_calls.rs
+++ b/src/api_calls/mod_calls.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api_calls::check_id_slug, request::request_rel, structures::mod_structs::*, Ferinth, Result,
+    api_calls::check_id_slug, request::request_rel, structures::project_structs::*, Ferinth, Result,
 };
 
 impl Ferinth {
@@ -14,7 +14,7 @@ impl Ferinth {
     ///     sodium_mod.title,
     ///     "Sodium",
     /// );
-    /// 
+    ///
     /// // You can also use the mod slug
     /// let ok_zoomer_mod = modrinth.get_mod("ok-zoomer").await?;
     /// assert_eq!(
@@ -26,7 +26,7 @@ impl Ferinth {
     /// ```
     pub async fn get_mod(&self, mod_id: &str) -> Result<Mod> {
         check_id_slug(mod_id)?;
-        Ok(request_rel(self, format!("/mod/{}", mod_id))
+        Ok(request_rel(self, format!("/project/{}", mod_id))
             .await?
             .json()
             .await?)

--- a/src/api_calls/project_calls.rs
+++ b/src/api_calls/project_calls.rs
@@ -3,20 +3,20 @@ use crate::{
 };
 
 impl Ferinth {
-    /// Get mod with ID `mod_id`
+    /// Get a project with ID `project_id`
     ///
     /// Example:
     /// ```rust
     /// # let modrinth = ferinth::Ferinth::new("ferinth-example");
     /// # tokio_test::block_on( async {
-    /// let sodium_mod = modrinth.get_mod("AANobbMI").await?;
+    /// let sodium_mod = modrinth.get_project("AANobbMI").await?;
     /// assert_eq!(
     ///     sodium_mod.title,
     ///     "Sodium",
     /// );
     ///
-    /// // You can also use the mod slug
-    /// let ok_zoomer_mod = modrinth.get_mod("ok-zoomer").await?;
+    /// // You can also use the project slug
+    /// let ok_zoomer_mod = modrinth.get_project("ok-zoomer").await?;
     /// assert_eq!(
     ///     ok_zoomer_mod.title,
     ///     "Ok Zoomer",
@@ -24,7 +24,7 @@ impl Ferinth {
     /// # Ok::<(), ferinth::Error>(())
     /// # } );
     /// ```
-    pub async fn get_mod(&self, mod_id: &str) -> Result<Mod> {
+    pub async fn get_project(&self, mod_id: &str) -> Result<Project> {
         check_id_slug(mod_id)?;
         Ok(request_rel(self, format!("/project/{}", mod_id))
             .await?

--- a/src/api_calls/tag_calls.rs
+++ b/src/api_calls/tag_calls.rs
@@ -1,7 +1,7 @@
 use crate::{request::request_rel, Ferinth, Result};
 
 impl Ferinth {
-    /// List the categories of mods
+    /// List the categories a project can take
     ///
     /// Example:
     /// ```rust
@@ -46,8 +46,8 @@ impl Ferinth {
     /// List the Minecraft versions
     ///
     /// Example: NO
-    /// 
-    /// I don't know why this exists. 
+    ///
+    /// I don't know why this exists.
     /// Just use [Mojang's version manifest](https://launchermeta.mojang.com/mc/game/version_manifest_v2.json) which is more informative
     pub async fn list_game_versions(&self) -> Result<Vec<String>> {
         Ok(request_rel(self, "/tag/game_version".into())

--- a/src/api_calls/user_calls.rs
+++ b/src/api_calls/user_calls.rs
@@ -28,13 +28,13 @@ impl Ferinth {
             .await?)
     }
 
-    /// Get a list of mod IDs of mods that the user owns
+    /// Get a list of project IDs of projects that the user owns
     ///
     /// Example:
     /// ```rust
     /// # let modrinth = ferinth::Ferinth::new("ferinth-example");
     /// # tokio_test::block_on( async {
-    /// let jellysquid_mods = modrinth.list_mods("TEZXhE2U").await?;
+    /// let jellysquid_projects = modrinth.list_projects("TEZXhE2U").await?;
     /// assert!(vec![
     ///         "hEOCdOgW".to_string(),
     ///         "AANobbMI".to_string(),
@@ -42,15 +42,15 @@ impl Ferinth {
     ///         "AZomiSrC".to_string()
     ///     ]
     ///     .iter()
-    ///     // So that the order of the mods isn't checked
+    ///     // So that the order of the projects isn't checked
     ///     .all(
-    ///         |mod_id| jellysquid_mods.contains(mod_id)
+    ///         |project_id| jellysquid_projects.contains(project_id)
     ///     )
     /// );
     /// # Ok::<(), ferinth::Error>(())
     /// # } );
     /// ```
-    pub async fn list_mods(&self, user_id: &str) -> Result<Vec<ID>> {
+    pub async fn list_projects(&self, user_id: &str) -> Result<Vec<ID>> {
         check_id_slug(user_id)?;
         Ok(request_rel(self, format!("/user/{}/projects", user_id))
             .await?

--- a/src/api_calls/user_calls.rs
+++ b/src/api_calls/user_calls.rs
@@ -52,7 +52,7 @@ impl Ferinth {
     /// ```
     pub async fn list_mods(&self, user_id: &str) -> Result<Vec<ID>> {
         check_id_slug(user_id)?;
-        Ok(request_rel(self, format!("/user/{}/mods", user_id))
+        Ok(request_rel(self, format!("/user/{}/projects", user_id))
             .await?
             .json()
             .await?)

--- a/src/api_calls/version_calls.rs
+++ b/src/api_calls/version_calls.rs
@@ -15,7 +15,7 @@ impl Ferinth {
     /// # tokio_test::block_on( async {
     /// let sodium_versions = modrinth.list_versions("AANobbMI").await?;
     /// assert_eq!(
-    ///     sodium_versions[0].mod_id,
+    ///     sodium_versions[0].project_id,
     ///     "AANobbMI",
     /// );
     /// # Ok::<(), ferinth::Error>(())
@@ -37,7 +37,7 @@ impl Ferinth {
     /// # tokio_test::block_on( async {
     /// let sodium_version = modrinth.get_version("xuWxRZPd").await?;
     /// assert_eq!(
-    ///     sodium_version.mod_id,
+    ///     sodium_version.project_id,
     ///     "AANobbMI",
     /// );
     /// # Ok::<(), ferinth::Error>(())
@@ -60,7 +60,7 @@ impl Ferinth {
     /// // A version file has the hash `795d4c12bffdb1b21eed5ff87c07ce5ca3c0dcbf`, so we can the version it belongs to
     /// let sodium_version = modrinth.get_version_from_file_hash("795d4c12bffdb1b21eed5ff87c07ce5ca3c0dcbf").await?;
     /// assert_eq!(
-    ///     sodium_version.mod_id,
+    ///     sodium_version.project_id,
     ///     "AANobbMI",
     /// );
     /// # Ok::<(), ferinth::Error>(())

--- a/src/api_calls/version_calls.rs
+++ b/src/api_calls/version_calls.rs
@@ -7,7 +7,7 @@ use crate::{
 use bytes::Bytes;
 
 impl Ferinth {
-    /// Get the versions of mod with `mod_id`
+    /// Get the versions of project with `project_id`
     ///
     /// Example:
     /// ```rust
@@ -21,12 +21,14 @@ impl Ferinth {
     /// # Ok::<(), ferinth::Error>(())
     /// # } );
     /// ```
-    pub async fn list_versions(&self, mod_id: &str) -> Result<Vec<Version>> {
-        check_id_slug(mod_id)?;
-        Ok(request_rel(self, format!("/project/{}/version", mod_id))
-            .await?
-            .json()
-            .await?)
+    pub async fn list_versions(&self, project_id: &str) -> Result<Vec<Version>> {
+        check_id_slug(project_id)?;
+        Ok(
+            request_rel(self, format!("/project/{}/version", project_id))
+                .await?
+                .json()
+                .await?,
+        )
     }
 
     /// Get version with ID `version_id`

--- a/src/api_calls/version_calls.rs
+++ b/src/api_calls/version_calls.rs
@@ -23,7 +23,7 @@ impl Ferinth {
     /// ```
     pub async fn list_versions(&self, mod_id: &str) -> Result<Vec<Version>> {
         check_id_slug(mod_id)?;
-        Ok(request_rel(self, format!("/mod/{}/version", mod_id))
+        Ok(request_rel(self, format!("/project/{}/version", mod_id))
             .await?
             .json()
             .await?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,29 +9,29 @@
 //!
 //! - All structure definitions based on <https://github.com/modrinth/labrinth/wiki/API-Documentation#structure-definitions>
 //! - Includes the following API calls:
-//!   - Get mod by mod ID
-//!   - List mod categories
+//!   - Get project by project ID
+//!   - List project categories
 //!   - List mod loaders
 //!   - List game versions
 //!   - Get user by user ID
 //!   - List team members by team ID
 //!   - Get version by version ID
 //!   - Get version by file hash
-//!   - List versions by mod ID
+//!   - List versions by project ID
 //!   - Download version file
 //!
 //! URL traversal is blocked because all IDs are verified.
 //! ```
 //! # let modrinth = ferinth::Ferinth::new("ferinth-example");
 //! # tokio_test::block_on( async {
-//! assert!(modrinth.get_mod("sodium/version").await.is_err());
+//! assert!(modrinth.get_project("sodium/version").await.is_err());
 //! # } );
 //! ```
 //!
 //! This crate uses [Rustls](https://docs.rs/rustls/) rather than OpenSSL, because OpenSSL is outdated and slower.
 //!
 //! The following features have not yet been implemented
-//! - Search mods
+//! - Search projects
 //! - User authentication
 //! - Get current user (constrained by the lack of user authentication)
 //!
@@ -63,12 +63,12 @@
 //! let api = Ferinth::new("example");
 //!
 //! // Now, lets get the Sodium mod
-//! // You can use the mod ID, or the mod slug
-//! // The mod ID will never change but the mod slug can change at anytime
-//! // Using the mod slug
-//! let sodium = api.get_mod("sodium").await?;
-//! // Using the mod ID
-//! let sodium = api.get_mod("AANobbMI").await?;
+//! // You can use the project ID, or the project slug
+//! // The project ID will never change but the project slug can change at anytime
+//! // Using the project slug
+//! let sodium = api.get_project("sodium").await?;
+//! // Using the project ID
+//! let sodium = api.get_project("AANobbMI").await?;
 //!
 //! // Now lets get the versions that the Sodium mod has
 //! let sodium_versions = api.list_versions("AANobbMI").await?;
@@ -113,7 +113,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 /// # use ferinth::Ferinth;
 /// let modrinth = Ferinth::new("ferinth-example");
 /// // Use the instance to call the API
-/// let sodium_mod = modrinth.get_mod("sodium");
+/// let sodium_mod = modrinth.get_project("sodium");
 /// ```
 pub struct Ferinth {
     client: reqwest::Client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! It uses [Reqwest](https://docs.rs/reqwest/) as its HTTPS client and deserialises responses to strongly typed structs using [SerDe](https://serde.rs/).
 //!
 //! ## Features
-//! 
+//!
 //! This crate includes the following:
 //!
 //! - All structure definitions based on <https://github.com/modrinth/labrinth/wiki/API-Documentation#structure-definitions>
@@ -19,7 +19,7 @@
 //!   - Get version by file hash
 //!   - List versions by mod ID
 //!   - Download version file
-//! 
+//!
 //! URL traversal is blocked because all IDs are verified.
 //! ```
 //! # let modrinth = ferinth::Ferinth::new("ferinth-example");
@@ -27,9 +27,9 @@
 //! assert!(modrinth.get_mod("sodium/version").await.is_err());
 //! # } );
 //! ```
-//! 
+//!
 //! This crate uses [Rustls](https://docs.rs/rustls/) rather than OpenSSL, because OpenSSL is outdated and slower.
-//! 
+//!
 //! The following features have not yet been implemented
 //! - Search mods
 //! - User authentication

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 use crate::{Ferinth, Result};
 use reqwest::{header::USER_AGENT, IntoUrl, Response};
 
-const API_URL_BASE: &str = "https://api.modrinth.com/api/v1";
+const API_URL_BASE: &str = "https://api.modrinth.com/v2";
 
 /// Perform a GET request on base url + `route` using `client`
 pub(crate) async fn request_rel(client: &Ferinth, route: String) -> Result<Response> {

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -1,4 +1,4 @@
-pub mod mod_structs;
+pub mod project_structs;
 pub mod user_structs;
 pub mod version_structs;
 

--- a/src/structures/project_structs.rs
+++ b/src/structures/project_structs.rs
@@ -7,62 +7,62 @@ use std::{
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct Mod {
-    /// The mod's ID
+pub struct Project {
+    /// The project's ID
     pub id: ID,
-    /// The mod's slug. This can change at any time
+    /// The project's slug. This can change at any time
     pub slug: String,
     /// The project type of the project
-    pub project_type: String,
-    /// The ID of the team that has ownership of this mod
+    pub project_type: ProjectType,
+    /// The ID of the team that has ownership of this project
     pub team: ID,
-    /// The mod's title or name
+    /// The project's title or name
     pub title: String,
-    /// A short description of the mod
+    /// A short description of the project
     pub description: String,
     /// A long form of the description
     pub body: String,
-    #[deprecated(note = "Read from `Mod.body` instead")]
-    /// A link to the long description of the mod
+    #[deprecated(note = "Read from `Project.body` instead")]
+    /// A link to the long description of the project
     pub body_url: Option<String>,
-    /// When the mod was first published
+    /// When the project was first published
     pub published: Datetime,
-    /// WHen the mod was last updated
+    /// WHen the project was last updated
     pub updated: Datetime,
 
-    /// The mod's status
-    pub status: ModStatus,
+    /// The project's status
+    pub status: ProjectStatus,
     /// The rejection data of the project
     pub moderator_message: Option<ModeratorMessage>,
 
-    /// The mod's license of the mod
+    /// The project's license
     pub license: License,
 
-    /// The mod's client side support range
-    pub client_side: ModSupportRange,
-    /// The mod's server side support range
-    pub server_side: ModSupportRange,
+    /// The project's client side support range
+    pub client_side: ProjectSupportRange,
+    /// The project's server side support range
+    pub server_side: ProjectSupportRange,
 
-    /// The total number of downloads the mod has
+    /// The total number of downloads the project has
     pub downloads: usize,
     /// The total number of followers this project has accumulated
     pub followers: u32,
 
-    /// A list of categories the mod is in
+    /// A list of categories the project is in
     pub categories: Vec<String>,
-    /// The mod's version listed as their IDs
+    /// The project's versions listed as their IDs
     pub versions: Vec<ID>,
-    /// The link to the mod's icon
+    /// The link to the project's icon
     pub icon_url: Option<String>,
-    /// A link to submit bugs or issues about the mod
+    /// A link to submit bugs or issues about the project
     pub issues_url: Option<String>,
-    /// A link to the mod's source code
+    /// A link to the project's source code
     pub source_url: Option<String>,
-    /// A link to the mod's wiki page or other relevant information
+    /// A link to the project's wiki page or other relevant information
     pub wiki_url: Option<String>,
-    /// A link to the mod's discord
+    /// A link to the project's discord
     pub discord_url: Option<String>,
-    /// A list of donation links the mod has
+    /// A list of donation links the project has
     pub donation_urls: Option<Vec<DonationLink>>,
 
     /// A string of URLs to visual content featuring the project
@@ -90,7 +90,7 @@ pub struct DonationLink {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-pub enum ModStatus {
+pub enum ProjectStatus {
     #[serde(rename = "approved")]
     Approved,
     #[serde(rename = "archived")]
@@ -108,7 +108,7 @@ pub enum ModStatus {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-pub enum ModSupportRange {
+pub enum ProjectSupportRange {
     #[serde(rename = "required")]
     Required,
     #[serde(rename = "optional")]
@@ -119,7 +119,7 @@ pub enum ModSupportRange {
     Unknown,
 }
 
-impl Display for ModSupportRange {
+impl Display for ProjectSupportRange {
     fn fmt(&self, fmt: &mut Formatter) -> std::result::Result<(), std::fmt::Error> {
         write!(
             fmt,
@@ -134,17 +134,25 @@ impl Display for ModSupportRange {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ModeratorMessage {
     pub message: String,
     pub body: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GalleryItem {
     pub url: String,
     pub featured: bool,
     pub title: Option<String>,
     pub description: Option<String>,
     pub created: Datetime,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ProjectType {
+    #[serde(rename = "mod")]
+    Mod,
+    #[serde(rename = "modpack")]
+    Modpack,
 }

--- a/src/structures/project_structs.rs
+++ b/src/structures/project_structs.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Project {
     /// The project's ID
     pub id: ID,

--- a/src/structures/project_structs.rs
+++ b/src/structures/project_structs.rs
@@ -2,8 +2,8 @@ use super::{Datetime, ID};
 use serde::{Deserialize, Serialize};
 use std::{
     clone::Clone,
-    fmt::{Display, Formatter},
     cmp::PartialEq,
+    fmt::{Display, Formatter},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -12,6 +12,8 @@ pub struct Mod {
     pub id: ID,
     /// The mod's slug. This can change at any time
     pub slug: String,
+    /// The project type of the project
+    pub project_type: String,
     /// The ID of the team that has ownership of this mod
     pub team: ID,
     /// The mod's title or name
@@ -27,16 +29,25 @@ pub struct Mod {
     pub published: Datetime,
     /// WHen the mod was last updated
     pub updated: Datetime,
+
     /// The mod's status
     pub status: ModStatus,
+    /// The rejection data of the project
+    pub moderator_message: Option<ModeratorMessage>,
+
     /// The mod's license of the mod
     pub license: License,
+
     /// The mod's client side support range
     pub client_side: ModSupportRange,
     /// The mod's server side support range
     pub server_side: ModSupportRange,
+
     /// The total number of downloads the mod has
     pub downloads: usize,
+    /// The total number of followers this project has accumulated
+    pub followers: u32,
+
     /// A list of categories the mod is in
     pub categories: Vec<String>,
     /// The mod's version listed as their IDs
@@ -53,6 +64,9 @@ pub struct Mod {
     pub discord_url: Option<String>,
     /// A list of donation links the mod has
     pub donation_urls: Option<Vec<DonationLink>>,
+
+    /// A string of URLs to visual content featuring the project
+    pub gallery: Vec<GalleryItem>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -79,6 +93,8 @@ pub struct DonationLink {
 pub enum ModStatus {
     #[serde(rename = "approved")]
     Approved,
+    #[serde(rename = "archived")]
+    Archived,
     #[serde(rename = "rejected")]
     Rejected,
     #[serde(rename = "draft")]
@@ -116,4 +132,19 @@ impl Display for ModSupportRange {
             }
         )
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ModeratorMessage {
+    pub message: String,
+    pub body: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GalleryItem {
+    pub url: String,
+    pub featured: bool,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub created: Datetime,
 }

--- a/src/structures/user_structs.rs
+++ b/src/structures/user_structs.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{clone::Clone, cmp::PartialEq};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct User {
     /// The user's ID
     pub id: ID,
@@ -25,6 +26,7 @@ pub struct User {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct TeamMember {
     /// The ID of the member's team
     pub team_id: String,

--- a/src/structures/user_structs.rs
+++ b/src/structures/user_structs.rs
@@ -28,8 +28,8 @@ pub struct User {
 pub struct TeamMember {
     /// The ID of the member's team
     pub team_id: String,
-    /// The team member's user ID
-    pub user_id: String,
+    /// The user associated with the member
+    pub user: User,
     /// This team member's role
     pub role: String,
     /// ? Unknown use

--- a/src/structures/version_structs.rs
+++ b/src/structures/version_structs.rs
@@ -7,7 +7,7 @@ use std::cmp::PartialEq;
 pub struct Version {
     /// The version's ID
     pub id: ID,
-    /// The ID of the mod this version is for
+    /// The ID of the project this version is for
     pub project_id: ID,
     /// The ID of the author who published this version
     pub author_id: ID,

--- a/src/structures/version_structs.rs
+++ b/src/structures/version_structs.rs
@@ -4,6 +4,7 @@ use std::clone::Clone;
 use std::cmp::PartialEq;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Version {
     /// The version's ID
     pub id: ID,
@@ -41,6 +42,7 @@ pub struct Version {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub enum VersionType {
     #[serde(rename = "alpha")]
     Alpha,

--- a/src/structures/version_structs.rs
+++ b/src/structures/version_structs.rs
@@ -1,18 +1,19 @@
+use super::*;
 use serde::{Deserialize, Serialize};
 use std::clone::Clone;
 use std::cmp::PartialEq;
-use super::*;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Version {
     /// The version's ID
     pub id: ID,
     /// The ID of the mod this version is for
-    pub mod_id: ID,
+    pub project_id: ID,
     /// The ID of the author who published this version
     pub author_id: ID,
     /// Whether the version is 'featured' (?) or not
     pub featured: bool,
+
     /// The name of this version
     pub name: String,
     /// The version's number. Ideally, this will follow semantic versioning
@@ -28,10 +29,11 @@ pub struct Version {
     pub downloads: usize,
     /// The version's type
     pub version_type: VersionType,
+
     /// A list of files available for download
     pub files: Vec<VersionFile>,
     /// This version's dependencies, as a list of dependencies' versions' IDs
-    pub dependencies: Vec<ID>,
+    pub dependencies: Vec<Dependency>,
     /// A list of Minecraft versions that this version supports
     pub game_versions: Vec<String>,
     /// The mod loaders that this version supports
@@ -41,11 +43,11 @@ pub struct Version {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub enum VersionType {
     #[serde(rename = "alpha")]
-	Alpha,
+    Alpha,
     #[serde(rename = "beta")]
-	Beta,
+    Beta,
     #[serde(rename = "release")]
-	Release
+    Release,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -56,6 +58,8 @@ pub struct VersionFile {
     pub url: String,
     /// The file's name
     pub filename: String,
+    /// Whether the file is the primary file of a version
+    pub primary: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -64,4 +68,26 @@ pub struct Hashes {
     pub sha512: Option<String>,
     /// The SHA1 hash of the version file
     pub sha1: Option<String>,
+}
+
+/// A dependency which describes what versions are required, break support, or are optional to the
+/// version's functionality
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Dependency {
+    /// The specific version id that the dependency uses
+    pub version_id: Option<ID>,
+    /// The project ID that the dependency is synced with and auto-updated
+    pub project_id: Option<ID>,
+    /// The type of the dependency
+    pub dependency_type: DependencyType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum DependencyType {
+    #[serde(rename = "required")]
+    Required,
+    #[serde(rename = "optional")]
+    Optional,
+    #[serde(rename = "incompatible")]
+    Incompatible,
 }


### PR DESCRIPTION
This is still a WIP, but I might as well open it already. V1 to V2 migration guide can be found [here](https://docs.modrinth.com/docs/migrations/v1-to-v2/)

- Routes have been corrected to account for the new naming (`mod` > `project`).
- Checked for feature parity with [the API repo](https://github.com/modrinth/labrinth/blob/v2.0.0) and added/renamed accordingly

To consider:
- The wording of comments, methods and structs is most likely going to need to be changed as mods are now called projects in preparation for modpack support
- `permissions` in `TeamMember` is defined [here](https://github.com/modrinth/labrinth/blob/f3234a6b5eedd6d6e804e4412905cc60f336c9a8/src/models/teams.rs#L25)
- Using `#[serde(deny_unknown_fields)]` to catch inconsistencies earlier may be useful
- Re-export `Bytes` to avoid having to explicitly add it to the dependency list if not used anywhere else.

I'd want to see support added for using filters in the queries. Maybe something like the following could work to still keep the text based ones simple:
```rust
struct Query {}

impl From<String> for Query {}
```
And then some logic inside each function (`get_mod`, `list_mods`, etc) to handle the filters that are valid for the endpoint being reached.