### PR TITLE
Remove option from file hashes

### DIFF
--- a/src/structures/version_structs.rs
+++ b/src/structures/version_structs.rs
@@ -53,9 +53,9 @@ pub struct VersionFile {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Hashes {
     /// The SHA512 hash of the version file
-    pub sha512: Option<String>,
+    pub sha512: String,
     /// The SHA1 hash of the version file
-    pub sha1: Option<String>,
+    pub sha1: String,
 }
 
 /// A dependency which describes what versions are required, break support, or are optional to the version's functionality


### PR DESCRIPTION
Corresponding to the current API specs (and I read it in the announcement channel of Modrinth's Discord) all old versions got their file hashes generated