### PR TITLE
Add SourcesJar and Unknown variants to AdditionalFileType enum

### DIFF
--- a/src/structures/version.rs
+++ b/src/structures/version.rs
@@ -124,4 +124,5 @@ pub enum RequestedStatus {
 pub enum AdditionalFileType {
     RequiredResourcePack,
     OptionalResourcePack,
+    SourcesJar
 }

--- a/src/structures/version.rs
+++ b/src/structures/version.rs
@@ -124,5 +124,7 @@ pub enum RequestedStatus {
 pub enum AdditionalFileType {
     RequiredResourcePack,
     OptionalResourcePack,
-    SourcesJar
+    SourcesJar,
+    #[serde(other)]
+    Unknown
 }


### PR DESCRIPTION
This fixes the error that I was getting with the [Fast Noise](https://modrinth.com/mod/zfastnoise) mod (and others getting it with Jade and Continuity), when doing ./ferium scan with it in the mods folder, this would show up:
```rust
unknown variant `sources-jar`, expected `required-resource-pack` or `optional-resource-pack` at line 1 column 57679
```

When removing that mod from mods folder, the scan command would go on as normal.

Verified locally by using a local copy of ferinth with this change and compiling ferium with it, the scan command works when having the mod in mod folder.

```toml
[patch.crates-io]
ferinth = { path = "./ferinth" }
```

Fixes https://github.com/gorilla-devs/ferium/issues/502